### PR TITLE
Add unit tests for org.languagetool.remote.RemoteResult, RemoteRuleMatch and RemoteServer

### DIFF
--- a/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteResultTest.java
+++ b/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteResultTest.java
@@ -1,0 +1,37 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2016 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.remote;
+
+import org.junit.Assert;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RemoteResultTest {
+
+  @Test
+  public void testGetLanguageDetectedCodeOutput() {
+    final RemoteServer remoteServer = new RemoteServer("LanguageTool", "", "");
+    final List matches = new ArrayList();
+    final RemoteResult objectUnderTest = new RemoteResult("English", "en", "en", "English", matches, remoteServer);
+    Assert.assertEquals(objectUnderTest.getLanguageDetectedCode(), "en");
+    Assert.assertEquals(objectUnderTest.getLanguageDetectedName(), "English");
+  }
+
+}

--- a/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteRuleMatchTest.java
+++ b/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteRuleMatchTest.java
@@ -1,0 +1,31 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2016 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.remote;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RemoteRuleMatchTest {
+
+  @Test
+  public void testToStringOutput() {
+    Assert.assertEquals("ruleId@0-1", new RemoteRuleMatch("ruleId", "msg", "context", 0, 0, 1).toString());
+  }
+
+}

--- a/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteServerTest.java
+++ b/languagetool-http-client/src/test/java/org/languagetool/remote/RemoteServerTest.java
@@ -1,0 +1,32 @@
+/* LanguageTool, a natural language style checker
+ * Copyright (C) 2016 Daniel Naber (http://www.danielnaber.de)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package org.languagetool.remote;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RemoteServerTest {
+
+  @Test
+  public void testToStringOutput() {
+    final RemoteServer objectUnderTest = new RemoteServer("Languagetool", "4.5-SNAPSHOT", "2019-02-05 17:54");
+    Assert.assertEquals("Languagetool/4.5-SNAPSHOT/2019-02-05 17:54", objectUnderTest.toString());
+  }
+
+}


### PR DESCRIPTION
These four tests have been reworked from those implemented using reflection by platform (of 5250 tests generated for the entire project, all but 175 contain reflection)
Although these tests are not very exciting, they make up two of the classes to 100% line coverage and, as discussed with Paul, I will revisit this project in the future to rework some more complex tests.

Hi,
I've analysed your codebase and seen some gaps in the coverage of:

- org.languagetool.remote.RemoteResult (100% of now lines covered)
- org.languagetool.remote.RemoteRuleMatch (100% of lines now covered)
- org.languagetool.remote.RemoteServer (86.67% lines now covered; was 80%)

I've written the tests for these functions with the help of [Diffblue](https://www.diffblue.com/) [Cover](https://www.diffblue.com/products).
Hopefully, these tests should help you detect regressions caused by future code changes.
